### PR TITLE
remove attribute discriminator value

### DIFF
--- a/lib/src/model/taxa_list_error.dart
+++ b/lib/src/model/taxa_list_error.dart
@@ -16,7 +16,7 @@ abstract class TaxaListError implements Built<TaxaListError, TaxaListErrorBuilde
   factory TaxaListError([void updates(TaxaListErrorBuilder b)]) = _$TaxaListError;
 
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults(TaxaListErrorBuilder b) => b..attr=b.discriminatorValue;
+  static void _defaults(TaxaListErrorBuilder b) => b;
 
   @BuiltValueSerializer(custom: true)
   static Serializer<TaxaListError> get serializer => _$TaxaListErrorSerializer();


### PR DESCRIPTION
```
../../../.pub-cache/git/mosquito-alert-dart-sdk-2b9c66248e08a57117c5f90a6690d108cabbe996/lib/src/model/taxa_list_error.dart:19:62: Error: The getter 'discriminatorValue' isn't defined for the class 'TaxaListErrorBuilder'.
 - 'TaxaListErrorBuilder' is from 'package:mosquito_alert/src/model/taxa_list_error.dart' ('../../../.pub-cache/git/mosquito-alert-dart-sdk-2b9c66248e08a57117c5f90a6690d108cabbe996/lib/src/model/taxa_list_error.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named 'discriminatorValue'.
  static void _defaults(TaxaListErrorBuilder b) => b..attr=b.discriminatorValue;
                                                             ^^^^^^^^^^^^^^^^^^
../../../.pub-cache/git/mosquito-alert-dart-sdk-2b9c66248e08a57117c5f90a6690d108cabbe996/lib/src/model/taxa_list_error.dart:19:55: Error: The setter 'attr' isn't defined for the class 'TaxaListErrorBuilder'.
 - 'TaxaListErrorBuilder' is from 'package:mosquito_alert/src/model/taxa_list_error.dart' ('../../../.pub-cache/git/mosquito-alert-dart-sdk-2b9c66248e08a57117c5f90a6690d108cabbe996/lib/src/model/taxa_list_error.dart').
Try correcting the name to the name of an existing setter, or defining a setter or field named 'attr'.
  static void _defaults(TaxaListErrorBuilder b) => b..attr=b.discriminatorValue;
                                                      ^^^^
Target kernel_snapshot_program failed: Exception
2

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:compileFlutterBuildDebug'.
> Process 'command '/Users/myself/fvm/versions/3.27.4@stable/bin/flutter'' finished with non-zero exit value 1

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 6s
Error: Gradle task assembleDebug failed with exit code 1

Exited (1).
```